### PR TITLE
La til read tilgang for teamdokumenthandtering:naisclioffset på aapen…

### DIFF
--- a/.nais/aiven-topics.yaml
+++ b/.nais/aiven-topics.yaml
@@ -25,6 +25,9 @@ spec:
     - team: teamdokumenthandtering
       application: dokmotaltinn
       access: read
+    - team: teamdokumenthandtering
+      application: naisclioffset
+      access: read
 
 #  --
 #


### PR DESCRIPTION
…-altinn-dokmot-mottatt.

App som kan brukes for å instrumentere offset til teamdokumenthandtering sine consumergroups.