### PR TITLE
Oppfolgingsplan kafka til aiven

### DIFF
--- a/altinnkanal/src/main/resources/aiven-routing.yaml
+++ b/altinnkanal/src/main/resources/aiven-routing.yaml
@@ -56,14 +56,17 @@ routes:
     serviceEditionCode: 87
 # Oppfølgingsplan
   - topics:
+      - alf.aapen-altinn-oppfolgingsplan-mottatt-v2
       - alf.aapen-altinn-metrics-mottatt
     serviceCode: 2913
     serviceEditionCode: 2
   - topics:
+      - alf.aapen-altinn-oppfolgingsplan-mottatt-v2
       - alf.aapen-altinn-metrics-mottatt
     serviceCode: 2913
     serviceEditionCode: 3
   - topics:
+      - alf.aapen-altinn-oppfolgingsplan-mottatt-v2
       - alf.aapen-altinn-metrics-mottatt
     serviceCode: 2913
     serviceEditionCode: 4

--- a/altinnkanal/src/main/resources/routing.yaml
+++ b/altinnkanal/src/main/resources/routing.yaml
@@ -1,20 +1,4 @@
 routes:
-  - topics:
-    - aapen-altinn-oppfolgingsplan-Mottatt
-    serviceCode: 2913
-    serviceEditionCode: 2
-  - topics:
-    - aapen-altinn-oppfolgingsplan-Mottatt
-    serviceCode: 2913
-    serviceEditionCode: 3
-  - topics:
-    - aapen-altinn-oppfolgingsplan-Mottatt
-    serviceCode: 2913
-    serviceEditionCode: 4
-  - topics:
-    - aapen-altinn-oppfolgingsplan-Mottatt
-    serviceCode: NavOppfPlan
-    serviceEditionCode: rapportering-sykmeldte
 # Målekort
   - topics:
     - aapen-altinn-maalekort-Mottatt


### PR DESCRIPTION
Fjerner routing på on-prem og legger til aiven-routing